### PR TITLE
Relative path fix

### DIFF
--- a/Kaliko.Logger.csproj
+++ b/Kaliko.Logger.csproj
@@ -41,7 +41,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Bin\</OutputPath>
+    <OutputPath>..\Bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -49,7 +49,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Bin\</OutputPath>
+    <OutputPath>..\Bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/LogProviders/FileLogProvider.cs
+++ b/LogProviders/FileLogProvider.cs
@@ -21,6 +21,7 @@ namespace Kaliko.LogProviders {
 
     internal class FileLogProvider : ILogProvider {
         private readonly string _logfile;
+        private static readonly string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
         public FileLogProvider(string filename, Logger.Severity treshold) {
             _logfile = filename;
@@ -36,7 +37,8 @@ namespace Kaliko.LogProviders {
 
         private void WriteToFile(string formattedMessage) {
             string fileName = GetFileName();
-            File.AppendAllText(fileName, formattedMessage);
+            string path = Path.Combine(BaseDirectory, fileName);
+            File.AppendAllText(path, formattedMessage);
         }
 
         private string GetFileName() {

--- a/LogProviders/FileLogProvider.cs
+++ b/LogProviders/FileLogProvider.cs
@@ -21,11 +21,23 @@ namespace Kaliko.LogProviders {
 
     internal class FileLogProvider : ILogProvider {
         private readonly string _logfile;
-        private static readonly string BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-
+        
         public FileLogProvider(string filename, Logger.Severity treshold) {
-            _logfile = filename;
+            _logfile = ConvertToAbsolutePath(filename);
             Treshold = treshold;
+        }
+
+        private string ConvertToAbsolutePath(string fileName) {
+            if (fileName.ToLower().StartsWith("|datadirectory|")) {
+                string dataPath = (string)AppDomain.CurrentDomain.GetData("DataDirectory");
+                if (!string.IsNullOrEmpty(dataPath)) {
+                    fileName = string.Format("{0}\\{1}", dataPath, fileName.Substring(15));
+                }
+            }
+
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string path = Path.Combine(baseDirectory, fileName);
+            return path;
         }
 
         public Logger.Severity Treshold { get; set; }
@@ -37,8 +49,7 @@ namespace Kaliko.LogProviders {
 
         private void WriteToFile(string formattedMessage) {
             string fileName = GetFileName();
-            string path = Path.Combine(BaseDirectory, fileName);
-            File.AppendAllText(path, formattedMessage);
+            File.AppendAllText(fileName, formattedMessage);
         }
 
         private string GetFileName() {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]


### PR DESCRIPTION
Added support for using the application root as base for relative paths as well as |DataDirectory| for the applications data directory (on web i.e. App_data).
